### PR TITLE
Add web-based interface with Flask backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# RecallIO Chat
+
+This project offers a small web chat that connects to OpenAI and RecallIO. A Flask backend handles the chat logic while a simple Next.js UI provides a modern interface.
+
+## Backend
+
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Fill out `config.json` with your OpenAI and RecallIO credentials.
+3. Start the Flask server:
+   ```bash
+   python server.py
+   ```
+
+## Frontend
+
+1. From the `frontend` directory install packages:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Open the shown URL in your browser and start chatting.
+

--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+  "openai": {
+    "api_key": ""
+  },
+  "recallio": {
+    "api_key": "",
+    "project_id": "",
+    "user_id": "default_user"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "recall-chat",
+  "private": true,
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+export default function Home() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userText = input;
+    setInput('');
+    setMessages(prev => [...prev, { from: 'You', text: userText }]);
+    try {
+      const res = await fetch('http://localhost:5000/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: userText })
+      });
+      const data = await res.json();
+      if (data.reply) {
+        setMessages(prev => [...prev, { from: 'Assistant', text: data.reply }]);
+      } else if (data.error) {
+        setMessages(prev => [...prev, { from: 'Error', text: data.error }]);
+      }
+    } catch (e) {
+      setMessages(prev => [...prev, { from: 'Error', text: String(e) }]);
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 600, margin: '20px auto', fontFamily: 'Arial' }}>
+      <h1>RecallIO Chat</h1>
+      <div style={{ border: '1px solid #ccc', padding: 10, height: 400, overflowY: 'scroll' }}>
+        {messages.map((m, i) => (
+          <div key={i}><strong>{m.from}:</strong> {m.text}</div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', marginTop: 10 }}>
+        <input
+          style={{ flex: 1, marginRight: 5 }}
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => (e.key === 'Enter' && sendMessage())}
+        />
+        <button onClick={sendMessage}>Send</button>
+      </div>
+    </div>
+  );
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+openai
+recallio

--- a/server.py
+++ b/server.py
@@ -1,0 +1,99 @@
+import json
+from flask import Flask, request, jsonify
+import openai
+from recallio import RecallioClient, MemoryWriteRequest, MemoryRecallRequest, RecallioAPIError
+
+CONFIG_FILE = 'config.json'
+
+
+def load_config():
+    with open(CONFIG_FILE, 'r') as f:
+        config = json.load(f)
+    if 'openai' not in config or not config['openai'].get('api_key'):
+        raise ValueError('OpenAI API key missing in config.json')
+    recall_cfg = config.get('recallio', {})
+    if not recall_cfg.get('api_key') or not recall_cfg.get('project_id'):
+        raise ValueError('RecallIO configuration missing in config.json')
+    return config
+
+
+def create_clients(cfg):
+    openai_client = openai.OpenAI(api_key=cfg['openai']['api_key'])
+    recall_client = RecallioClient(api_key=cfg['recallio']['api_key'])
+    return openai_client, recall_client
+
+
+app = Flask(__name__)
+
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    data = request.get_json(force=True)
+    user_text = (data.get('message') or '').strip()
+    if not user_text:
+        return jsonify({'error': 'message is required'}), 400
+
+    cfg = app.config['cfg']
+    openai_client = app.config['openai_client']
+    recall_client = app.config['recall_client']
+    project_id = cfg['recallio']['project_id']
+    user_id = cfg['recallio'].get('user_id', 'default_user')
+
+    try:
+        recall_client.write_memory(
+            MemoryWriteRequest(userId=user_id, projectId=project_id, content=user_text, consentFlag=True)
+        )
+    except Exception as e:
+        return jsonify({'error': f'RecallIO write failed: {e}'}), 500
+
+    summary_text = ''
+    try:
+        recall_req = MemoryRecallRequest(
+            projectId=project_id,
+            userId=user_id,
+            query=user_text,
+            scope='user',
+            summarized=True,
+            similarityThreshold=0.5,
+            limit=10,
+        )
+        memories = recall_client.recall_memory(recall_req)
+        if memories:
+            summary = memories[0]
+            if summary.content:
+                summary_text = summary.content
+    except RecallioAPIError as e:
+        summary_text = ''
+    except Exception as e:
+        return jsonify({'error': f'RecallIO recall failed: {e}'}), 500
+
+    messages = []
+    if summary_text:
+        messages.append({'role': 'system', 'content': f'Recalled Summary: {summary_text}'})
+    messages.append({'role': 'user', 'content': user_text})
+
+    try:
+        response = openai_client.chat.completions.create(model='gpt-3.5-turbo', messages=messages)
+        reply = response.choices[0].message.content
+    except Exception as e:
+        return jsonify({'error': f'OpenAI error: {e}'}), 500
+
+    return jsonify({'reply': reply})
+
+
+def main():
+    try:
+        cfg = load_config()
+        openai_client, recall_client = create_clients(cfg)
+    except Exception as e:
+        print(f'Configuration Error: {e}')
+        return
+
+    app.config['cfg'] = cfg
+    app.config['openai_client'] = openai_client
+    app.config['recall_client'] = recall_client
+    app.run(debug=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement Flask backend server with RecallIO and OpenAI
- store only user messages and recall 10 memories at similarity 0.5
- provide Next.js frontend for a modern UI
- update config instructions in README
- list flask in requirements

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_686453fd34e4832eaaeb8edcf7452d7d