### PR TITLE
Use RecallIO facts with version 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RecallIO Chat
 
 
-This project provides a simple desktop chat application built with Tkinter. It connects to OpenAI and RecallIO, storing your messages and recalling summarized memories relevant to your input.
+This project provides a simple desktop chat application built with Tkinter. It connects to OpenAI and RecallIO, storing your messages and recalling factual knowledge relevant to your input.
 
 ## Setup
 =======
@@ -21,4 +21,4 @@ Start the chat application with:
 ```bash
 python chat_gui.py
 ```
-The top area shows the conversation while the lower panel displays the latest recalled summary from RecallIO.
+The top area shows the conversation while the lower panel displays the latest recalled facts from RecallIO.

--- a/chat_gui.py
+++ b/chat_gui.py
@@ -1,7 +1,12 @@
 import json
 import tkinter as tk
 from tkinter import scrolledtext
-from recallio import RecallioClient, MemoryWriteRequest, MemoryRecallRequest, RecallioAPIError
+from recallio import (
+    RecallioClient,
+    MemoryWriteRequest,
+    MemoryRecallRequest,
+    RecallioAPIError,
+)
 import openai
 import time
 
@@ -40,7 +45,7 @@ class ChatApp:
         self.chat_area.configure(state='disabled')
         self.chat_area.pack(padx=10, pady=10, fill='both', expand=True)
 
-        tk.Label(self.root, text='Recalled summary:', bg='#f5f5f5', fg='#333').pack(anchor='w', padx=10)
+        tk.Label(self.root, text='Recalled facts:', bg='#f5f5f5', fg='#333').pack(anchor='w', padx=10)
         self.recall_area = tk.Text(self.root, height=4, bg='#eef', wrap=tk.WORD)
         self.recall_area.configure(state='disabled')
         self.recall_area.pack(padx=10, pady=(0, 10), fill='x')
@@ -71,7 +76,7 @@ class ChatApp:
         self.entry.delete(0, tk.END)
         self.append_chat('You', user_text)
 
-        summary_text = ''
+        fact_text = ''
         recall_time = 0
         try:
             start_time = time.time()
@@ -86,20 +91,23 @@ class ChatApp:
             )
             memories = self.recall_client.recall_memory(recall_req)
             recall_time = time.time() - start_time
-            if memories:
-                first = memories[0]
-                summary_text = getattr(first, 'content', '') or getattr(first, 'summary', '')
+            fact_strings = []
+            for mem in memories:
+                fact_strings.append(
+                    getattr(mem, 'content', '') or getattr(mem, 'summary', '')
+                )
+            fact_text = "; ".join(fs for fs in fact_strings if fs)
         except RecallioAPIError:
-            summary_text = ''
+            fact_text = ''
         except Exception as e:
             self.append_chat('Error', f'RecallIO recall failed: {e}')
             return
-        if summary_text:
-            self.update_recall(f"[Recall time: {recall_time:.3f}s] {summary_text}")
+        if fact_text:
+            self.update_recall(f"[Recall time: {recall_time:.3f}s] {fact_text}")
 
         messages = []
-        if summary_text:
-            messages.append({'role': 'system', 'content': f'This is what you know about the user: {summary_text}'})
+        if fact_text:
+            messages.append({'role': 'system', 'content': f'These facts about the user may help you: {fact_text}'})
         messages.append({'role': 'user', 'content': user_text})
 
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openai
-recallio
+recallio==1.1.2
+


### PR DESCRIPTION
## Summary
- upgrade `recallio` dependency to `1.1.2`
- fetch facts from RecallIO using `MemoryRecallRequest`
- pass recalled facts to OpenAI and display them in the UI
- update docs to mention factual recall

## Testing
- `python -m py_compile chat_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_686c5289ebb4832eb22e4e72e9b87aaa